### PR TITLE
refactor/src-to-file_comparison-import-fixes

### DIFF
--- a/file_comparison/cli/cli.py
+++ b/file_comparison/cli/cli.py
@@ -1,5 +1,5 @@
 import click
-from src.filtering.directory_comparer import DirectoryComparer
+from file_comparison.filtering.directory_comparer import DirectoryComparer
 
 
 @click.command()

--- a/file_comparison/filtering/directory_comparer.py
+++ b/file_comparison/filtering/directory_comparer.py
@@ -1,5 +1,5 @@
 from .collection_tools import get_list_differences, get_dict_differences, get_dict_where_value_differs
-from src.loader.directory_reader import DirectoryReader
+from file_comparison.loader.directory_reader import DirectoryReader
 
 LONG_BREAK = "-"*50
 

--- a/file_comparison/filtering/directory_comparer_integration_test.py
+++ b/file_comparison/filtering/directory_comparer_integration_test.py
@@ -1,8 +1,7 @@
 import pytest
 import os
 import test
-from src.filtering.collection_tools import get_dict_differences
-from src.filtering.directory_comparer import DirectoryComparer
+from file_comparison.filtering.directory_comparer import DirectoryComparer
 
 path = os.path.dirname(test.__file__)
 dir1 = os.path.join(path, "example_directories", "test_directory_a")

--- a/file_comparison/filtering/directory_comparer_test.py
+++ b/file_comparison/filtering/directory_comparer_test.py
@@ -1,6 +1,6 @@
 import unittest
-from src.filtering.collection_tools import get_dict_differences
-from src.filtering.directory_comparer import DirectoryComparer
+from file_comparison.filtering.collection_tools import get_dict_differences
+from file_comparison.filtering.directory_comparer import DirectoryComparer
 
 
 class TestDirectoryComparer(unittest.TestCase):


### PR DESCRIPTION
## Changed

- Some imports were still using the old `src` instead of `file_comparison` which has now been fixed